### PR TITLE
Release v0.3.0: random generation, docs improvements, expanded tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MulticomplexNumbers"
 uuid = "d39bb3b7-cc9c-4bb9-be86-52b494dfee17"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Chris Waudby <c.waudby@ucl.ac.uk> and contributors"]
 
 [deps]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -191,35 +191,40 @@ The package supports random number generation for multicomplex numbers:
 ### Uniform Distribution
 
 ```julia
-rand([rng], Multicomplex{T,N,C})
+rand([rng], Multicomplex{T,N,C})            # single random number
+rand([rng], Multicomplex{T,N,C}, dims...)    # array of random numbers
 ```
 
-Generates a random multicomplex number with components drawn from the default distribution for type `T`.
+Generates random multicomplex numbers with components drawn from the default distribution for type `T`.
 
 **Example:**
 ```julia
 julia> rand(Multicomplex{Float64,1,2})
 0.234 + 0.891*im1
 
-julia> rand(Multicomplex{Float64,2,4})
-(0.123 + 0.456*im1) + (0.789 + 0.234*im1)*im2
+julia> rand(Multicomplex{Float64,2,4}, 3)    # vector of 3 random bicomplex numbers
+3-element Vector{Multicomplex{Float64, 2, 4}}: ...
+
+julia> rand(Multicomplex{Float64,1,2}, 2, 3) # 2×3 matrix
+2×3 Matrix{Multicomplex{Float64, 1, 2}}: ...
 ```
 
 ### Normal Distribution
 
 ```julia
-randn([rng], Multicomplex{T,N,C}) where {T<:AbstractFloat}
+randn([rng], Multicomplex{T,N,C})            # single random number
+randn([rng], Multicomplex{T,N,C}, dims...)   # array of random numbers
 ```
 
-Generates a random multicomplex number with components drawn from a standard normal distribution. Only available for floating-point types.
+Generates random multicomplex numbers with components drawn from a standard normal distribution. Only available for floating-point types.
 
 **Example:**
 ```julia
 julia> randn(Multicomplex{Float64,1,2})
 -0.543 + 1.234*im1
 
-julia> randn(Multicomplex{Float64,2,4})
-(0.891 - 0.234*im1) + (-1.567 + 0.432*im1)*im2
+julia> randn(Multicomplex{Float64,2,4}, 5)   # vector of 5 random bicomplex numbers
+5-element Vector{Multicomplex{Float64, 2, 4}}: ...
 ```
 
 ---
@@ -256,7 +261,7 @@ bfft(A, unit [, dims])     # Backward FFT (returns copy)
 using MulticomplexNumbers
 using FFTW
 
-data = [Multicomplex(rand(4)...) for _ in 1:64]
+data = rand(Multicomplex{Float64,2,4}, 64)
 
 # In-place forward and inverse
 fft!(data, 1)

--- a/docs/src/guide/creating.md
+++ b/docs/src/guide/creating.md
@@ -42,7 +42,7 @@ Number
 
 ## Using Imaginary Units
 
-The package exports `im1` through `im6`:
+The package exports `im1` through `im6` as predefined constants, and [`imN(n)`](@ref) for programmatic construction of any imaginary unit:
 
 ```@repl creating
 using MulticomplexNumbers
@@ -55,6 +55,19 @@ im3  # Third imaginary unit
 z = 3.0 + 4.0*im1                           # Order 1
 w = 1.0 + 2.0*im1 + 3.0*im2                 # Order 2 (auto-promoted)
 v = 1.0 + im1 + im2 + im3 + im1*im2*im3    # Order 3
+```
+
+For orders beyond 6, or when constructing units programmatically (e.g. in a loop), use [`imN`](@ref):
+
+```@repl creating
+using MulticomplexNumbers
+
+imN(2) == im2  # Same as the predefined constant
+
+# Useful in loops over dimensions
+for n in 1:3
+    println("im$n squares to ", imN(n)^2 |> realest)
+end
 ```
 
 ---
@@ -145,6 +158,24 @@ typeof(z)
 
 # Compute with high precision
 exp(z)
+```
+
+---
+
+## Random Multicomplex Numbers
+
+Generate random multicomplex numbers using `rand` and `randn`:
+
+```@repl creating
+using MulticomplexNumbers
+
+rand(Multicomplex{Float64,1,2})       # Uniform components in [0, 1)
+
+randn(Multicomplex{Float64,2,4})      # Normal components
+
+rand(Multicomplex{Float64,1,2}, 3)    # Array of 3 random order-1 numbers
+
+rand(Multicomplex{Float64,2,4}, 2, 3) # 2×3 matrix of random order-2 numbers
 ```
 
 ---

--- a/docs/src/guide/fft.md
+++ b/docs/src/guide/fft.md
@@ -28,7 +28,7 @@ using MulticomplexNumbers
 using FFTW
 
 # Create bicomplex data
-data = [Multicomplex(rand(4)...) for _ in 1:64]
+data = rand(Multicomplex{Float64,2,4}, 64)
 
 # FFT along im1 (treating im1 as the complex unit)
 fft!(data, 1)
@@ -82,152 +82,7 @@ fft!(data_3d, 3, dims=3)  # Second indirect (im3)
 
 ---
 
-## Complete Example: 2D NMR Processing
-
-```julia
-using MulticomplexNumbers
-using FFTW
-
-# Create synthetic 2D NMR signal
-function create_2d_nmr_signal(n1, n2, freq1, freq2)
-    signal = Array{Multicomplex{Float64, 2, 4}}(undef, n1, n2)
-
-    for j in 1:n2, i in 1:n1
-        # Time points
-        t1 = (i-1) / n1
-        t2 = (j-1) / n2
-
-        # Oscillating signal with decay
-        # Direct dimension (im1)
-        s1_real = cos(2π * freq1 * t1) * exp(-t1 * 5.0)
-        s1_imag = sin(2π * freq1 * t1) * exp(-t1 * 5.0)
-
-        # Indirect dimension (im2)
-        s2_real = cos(2π * freq2 * t2) * exp(-t2 * 3.0)
-        s2_imag = sin(2π * freq2 * t2) * exp(-t2 * 3.0)
-
-        # Combine as bicomplex
-        signal[i, j] = Multicomplex(
-            s1_real * s2_real,     # real-real
-            s1_imag * s2_real,     # im1 coefficient
-            s1_real * s2_imag,     # im2 coefficient
-            s1_imag * s2_imag      # im1*im2 coefficient
-        )
-    end
-
-    return signal
-end
-
-# Generate signal
-fid = create_2d_nmr_signal(128, 64, 10.0, 15.0)
-
-# Process: FFT both dimensions
-fft!(fid, 1, dims=1)  # Transform direct dimension
-fft!(fid, 2, dims=2)  # Transform indirect dimension
-
-# The peak should appear near indices corresponding to the frequencies
-# (11, 16) for frequencies 10 and 15 out of 128 and 64 points
-```
-
----
-
-## Phase Correction
-
-Phase correction is simply multiplication by a phase factor. Use the appropriate imaginary unit for each dimension:
-
-```julia
-using MulticomplexNumbers
-using FFTW
-
-# Create and transform data
-fid = create_2d_nmr_signal(64, 32, 5.0, 10.0)
-fft!(fid, 1, dims=1)
-fft!(fid, 2, dims=2)
-
-# Zero-order phase correction: multiply by exp(imN * θ)
-fid .*= exp(im1 * π/6)   # 30° correction for direct dimension
-fid .*= exp(im2 * π/4)   # 45° correction for indirect dimension
-
-# For first-order (linear) phase correction, apply varying phases across the dimension
-n = size(fid, 1)
-for i in 1:n
-    θ = π/180 * (i - 1)  # 1° per point
-    fid[i, :] .*= exp(im1 * θ)
-end
-```
-
----
-
-## Extracting Complex Sub-Components
-
-After processing, you often want to extract specific complex projections:
-
-```julia
-using MulticomplexNumbers
-using FFTW
-
-# Process 2D spectrum
-fid = create_2d_nmr_signal(64, 32, 5.0, 10.0)
-fft!(fid, 1, dims=1)
-fft!(fid, 2, dims=2)
-
-# Extract the real/im1 complex spectrum (traditional F1 dimension)
-# This gives you the spectrum with im1 as the complex unit
-spectrum_im1 = real.(fid)  # Returns Multicomplex{Float64, 1, 2} array
-
-# Extract as actual Complex numbers for plotting/analysis
-complex_im1 = ascomplex([spectrum_im1[i, j] for i in 1:64, j in 1:32], 1)
-
-# Extract the real/im2 complex spectrum
-# For each point, we want real + im2*i
-function extract_im2_component(data)
-    n1, n2 = size(data)
-    result = Array{Complex{Float64}}(undef, n1, n2)
-    for j in 1:n2, i in 1:n1
-        z = data[i, j]
-        result[i, j] = Complex(realest(z), component(z, 3))
-    end
-    return result
-end
-
-complex_im2 = extract_im2_component(fid)
-
-# Or use ascomplex for the full array
-# This creates a view that maps the specified unit to Complex{T}
-complex_view = ascomplex(fid, 1)  # Map im1 → im (complex unit)
-```
-
----
-
-## Practical Tips for NMR
-
-1. **Dimension-Unit Association**: Always associate `im1` with the direct (acquisition) dimension, `im2` with the first indirect, `im3` with the second indirect, etc.
-
-2. **Processing Order**: Process dimensions in the order that makes sense for your experiment, typically:
-   ```julia
-   fft!(data, 1, dims=1)  # Direct first
-   fft!(data, 2, dims=2)  # Then indirect
-   ```
-
-3. **Phase Correction**: Apply phase corrections using the appropriate imaginary unit for each dimension:
-   - Direct dimension: multiply by `exp(im1 * θ)`
-   - First indirect: multiply by `exp(im2 * θ)`
-   - Second indirect: multiply by `exp(im3 * θ)`
-
-4. **Memory Efficiency**: FFT is performed in-place, modifying the original array. Make a copy if you need to preserve the original:
-   ```julia
-   fid_copy = copy(fid)
-   fft!(fid_copy, 1, dims=1)
-   ```
-
-5. **Extracting Real Spectra**: For publication, you typically want the magnitude:
-   ```julia
-   magnitude_spectrum = abs.(realest.(fid))
-   ```
-
----
-
-## Advanced: Custom FFT Dimensions
+## Custom FFT Dimensions
 
 You can apply FFT along specific array dimensions:
 
@@ -324,7 +179,7 @@ end
 using MulticomplexNumbers
 using FFTW
 
-fid = [Multicomplex(rand(4)...) for _ in 1:64]
+fid = rand(Multicomplex{Float64,2,4}, 64)
 fft!(fid, 1)
 
 # Center the zero-frequency component

--- a/src/base.jl
+++ b/src/base.jl
@@ -265,18 +265,19 @@ end
 
 """
     randn([rng=GLOBAL_RNG], ::Type{Multicomplex{T,N,C}}) where {T<:AbstractFloat}
+    randn([rng=GLOBAL_RNG], ::Type{Multicomplex{T,N,C}}, dims...) where {T<:AbstractFloat}
 
-Generate a random multicomplex number with components drawn from a standard normal distribution.
+Generate random multicomplex numbers with components drawn from a standard normal distribution.
 
-Only available for floating-point types.
+Only available for floating-point types. Supports generating arrays via `dims` arguments.
 
 # Examples
 ```julia
 julia> randn(Multicomplex{Float64,1,2})
 -0.543 + 1.234*im1
 
-julia> randn(Multicomplex{Float64,2,4})
-(0.891 - 0.234*im1) + (-1.567 + 0.432*im1)*im2
+julia> randn(Multicomplex{Float64,2,4}, 3)
+3-element Vector{Multicomplex{Float64, 2, 4}}: ...
 ```
 """
 function Base.randn(rng::AbstractRNG, ::Type{Multicomplex{T,N,C}}) where {T<:AbstractFloat,N,C}
@@ -285,6 +286,18 @@ end
 
 # Convenience methods without explicit RNG
 Base.randn(::Type{Multicomplex{T,N,C}}) where {T<:AbstractFloat,N,C} = randn(Random.default_rng(), Multicomplex{T,N,C})
+
+# Array-generating methods for randn
+function Base.randn(rng::AbstractRNG, ::Type{Multicomplex{T,N,C}}, dims::Dims) where {T<:AbstractFloat,N,C}
+    A = Array{Multicomplex{T,N,C}}(undef, dims)
+    for i in eachindex(A)
+        A[i] = randn(rng, Multicomplex{T,N,C})
+    end
+    A
+end
+Base.randn(rng::AbstractRNG, ::Type{Multicomplex{T,N,C}}, dims::Integer...) where {T<:AbstractFloat,N,C} = randn(rng, Multicomplex{T,N,C}, Dims(dims))
+Base.randn(::Type{Multicomplex{T,N,C}}, dims::Dims) where {T<:AbstractFloat,N,C} = randn(Random.default_rng(), Multicomplex{T,N,C}, dims)
+Base.randn(::Type{Multicomplex{T,N,C}}, dims::Integer...) where {T<:AbstractFloat,N,C} = randn(Random.default_rng(), Multicomplex{T,N,C}, Dims(dims))
 
 
 ##############

--- a/test/base_test.jl
+++ b/test/base_test.jl
@@ -876,6 +876,35 @@ end
     m_int = rand(Multicomplex{Int,1,2})
     @test m_int isa Multicomplex{Int,1,2}
 
+    # Test rand array generation
+    v = rand(Multicomplex{Float64,1,2}, 5)
+    @test v isa Vector{Multicomplex{Float64,1,2}}
+    @test length(v) == 5
+
+    M = rand(Multicomplex{Float64,2,4}, 3, 4)
+    @test M isa Matrix{Multicomplex{Float64,2,4}}
+    @test size(M) == (3, 4)
+
+    # Test randn array generation
+    v = randn(Multicomplex{Float64,1,2}, 5)
+    @test v isa Vector{Multicomplex{Float64,1,2}}
+    @test length(v) == 5
+
+    M = randn(Multicomplex{Float64,2,4}, 3, 4)
+    @test M isa Matrix{Multicomplex{Float64,2,4}}
+    @test size(M) == (3, 4)
+
+    # Test randn array generation with explicit RNG
+    rng = MersenneTwister(789)
+    v = randn(rng, Multicomplex{Float64,1,2}, 3)
+    @test v isa Vector{Multicomplex{Float64,1,2}}
+    @test length(v) == 3
+
+    # Test randn array reproducibility
+    rng1 = MersenneTwister(999)
+    rng2 = MersenneTwister(999)
+    @test randn(rng1, Multicomplex{Float64,2,4}, 3) == randn(rng2, Multicomplex{Float64,2,4}, 3)
+
     # Test type inference
     @test @inferred(rand(Multicomplex{Float64,1,2})) isa Multicomplex
     @test @inferred(randn(Multicomplex{Float64,1,2})) isa Multicomplex
@@ -905,4 +934,132 @@ end
     # error on non-positive
     @test_throws ArgumentError imN(0)
     @test_throws ArgumentError imN(-1)
+end
+
+@testset "Conjugation" begin
+    # Order 1: conj negates imaginary part
+    m1 = Multicomplex(1.0, 2.0)
+    @test conj(m1) == Multicomplex(1.0, -2.0)
+
+    # Order 2: conj negates the highest imaginary component
+    m2 = Multicomplex(1.0, 2.0, 3.0, 4.0)
+    @test conj(m2) == Multicomplex(1.0, 2.0, -3.0, -4.0)
+
+    # conj(conj(m)) == m
+    @test conj(conj(m2)) == m2
+
+    # Type inference
+    @test @inferred(conj(m1)) isa Multicomplex
+end
+
+@testset "Absolute value and norm" begin
+    using LinearAlgebra
+
+    m1 = Multicomplex(3.0, 4.0)
+    @test abs2(m1) ≈ 25.0
+    @test abs(m1) ≈ 5.0
+    @test norm(m1) ≈ 5.0
+
+    m2 = Multicomplex(1.0, 2.0, 3.0, 4.0)
+    @test abs2(m2) ≈ 30.0
+    @test abs(m2) ≈ sqrt(30.0)
+end
+
+@testset "log and sqrt" begin
+    # Order 1: matches complex
+    z = 0.5 + 0.3im
+    m = Multicomplex(0.5, 0.3)
+    @test log(m) ≈ Multicomplex(log(z))
+    @test sqrt(m) ≈ Multicomplex(sqrt(z))
+
+    # Inverse relationships: exp(log(m)) ≈ m
+    m2 = Multicomplex(0.5, 0.3, 0.2, 0.1)
+    @test exp(log(m2)) ≈ m2 rtol=1e-12
+    @test sqrt(m2)^2 ≈ m2 rtol=1e-12
+
+    # Type inference
+    @test @inferred(log(Multicomplex(1.0, 0.5))) isa Multicomplex
+    @test @inferred(sqrt(Multicomplex(1.0, 0.5))) isa Multicomplex
+end
+
+@testset "Powers" begin
+    m = Multicomplex(1.0, 2.0)
+    @test m^2 ≈ m * m
+    @test m^3 ≈ m * m * m
+    @test m^0 ≈ Multicomplex(1.0, 0.0)
+    @test m^(-1) ≈ inv(m)
+
+    # Non-integer power
+    @test m^0.5 ≈ sqrt(m)
+
+    # Higher order
+    m2 = Multicomplex(0.5, 0.3, 0.2, 0.1)
+    @test m2^2 ≈ m2 * m2 rtol=1e-12
+end
+
+@testset "Conversions and promotions" begin
+    # Real to multicomplex conversion
+    @test Multicomplex{Float64,1,2}(3) == Multicomplex(3.0, 0.0)
+    @test Multicomplex{Float64,2,4}(3) == Multicomplex(3.0, 0.0, 0.0, 0.0)
+
+    # Complex to multicomplex conversion
+    @test Multicomplex{Float64,1,2}(1+2im) == Multicomplex(1.0, 2.0)
+    @test Multicomplex{Float64,2,4}(1+2im) == Multicomplex(1.0, 2.0, 0.0, 0.0)
+
+    # Multicomplex to real conversion
+    @test Float64(Multicomplex(5.0)) == 5.0
+    @test_throws InexactError Float64(Multicomplex(1.0, 2.0))
+
+    # Order promotion
+    m1 = Multicomplex{Float64,1,2}(SVector(1.0, 2.0))
+    m2_promoted = Multicomplex{Float64,2,4}(m1)
+    @test m2_promoted == Multicomplex(1.0, 2.0, 0.0, 0.0)
+
+    # Type widening
+    @test widen(Multicomplex{Float32,1,2}) == Multicomplex{Float64,1,2}
+
+    # float conversion
+    @test float(Multicomplex{Int,1,2}) == Multicomplex{Float64,1,2}
+    @test float(Multicomplex{Float64,1,2}) == Multicomplex{Float64,1,2}
+end
+
+@testset "Property tests" begin
+    m = Multicomplex(5.0, 0.0)
+    @test isinteger(m) == true
+    @test isinteger(Multicomplex(5.5, 0.0)) == false
+    @test isinteger(Multicomplex(5.0, 1.0)) == false
+
+    @test isfinite(Multicomplex(1.0, 2.0)) == true
+    @test isfinite(Multicomplex(Inf, 2.0)) == false
+
+    @test isnan(Multicomplex(1.0, 2.0)) == false
+    @test isnan(Multicomplex(NaN, 2.0)) == true
+
+    @test isinf(Multicomplex(1.0, 2.0)) == false
+    @test isinf(Multicomplex(Inf, 2.0)) == true
+
+    @test iszero(Multicomplex(0.0, 0.0)) == true
+    @test iszero(Multicomplex(1.0, 0.0)) == false
+
+    @test isone(Multicomplex(1.0, 0.0)) == true
+    @test isone(Multicomplex(1.0, 1.0)) == false
+end
+
+@testset "Hashing" begin
+    m1 = Multicomplex(1.0, 2.0)
+    m2 = Multicomplex(1.0, 2.0)
+    m3 = Multicomplex(1.0, 3.0)
+
+    @test hash(m1) == hash(m2)
+    @test hash(m1) != hash(m3)
+
+    # Can be used as dictionary keys
+    d = Dict(m1 => "a")
+    @test d[m2] == "a"
+end
+
+@testset "flipsign" begin
+    m = Multicomplex(1.0, 2.0)
+    @test flipsign(m, 1.0) == m
+    @test flipsign(m, -1.0) == -m
 end


### PR DESCRIPTION
- Add randn array generation (dims... support) alongside existing rand
- Document imN alongside im1…im6 in creating guide with loop examples
- Remove detailed NMR examples from FFT doc page (covered in applications/nmr)
- Replace manual Multicomplex(rand(...)...) with rand(Multicomplex{...}) in docs
- Add tests for conj, abs/abs2/norm, log/sqrt, powers, conversions,
  property tests, hashing, flipsign, and rand/randn array generation
- Bump version to 0.3.0

https://claude.ai/code/session_01StvTWEtUgXNZoos7J6BsGR