### PR TITLE
Prepare JOSS submission and v1.0.0 release

### DIFF
--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -1,0 +1,24 @@
+name: Benchmarks
+on:
+  pull_request_target:
+    branches:
+      - main
+
+# Needed so the action can post/update the results comment on the PR.
+permissions:
+  pull-requests: write
+
+# Only keep the latest benchmark run per PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      # Runs benchmark/benchmarks.jl (the SUITE), comparing this PR against the
+      # default branch, and posts collapsible runtime + memory tables as a PR comment.
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: '1'

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -1,6 +1,6 @@
 name: Benchmarks
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -24,3 +24,7 @@ jobs:
           julia-version: '1'
           # Extra packages the benchmark script needs beyond the package itself.
           extra-pkgs: StaticArrays,FFTW
+          # Freeze the benchmark script to the PR head rather than the default
+          # (the base branch), so benchmarks added in the PR — e.g. the fft
+          # group — are measured on both revisions and show up in the comparison.
+          bench-on: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -22,3 +22,5 @@ jobs:
       - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
         with:
           julia-version: '1'
+          # Extra packages the benchmark script needs beyond the package itself.
+          extra-pkgs: StaticArrays,FFTW

--- a/.github/workflows/DraftPDF.yml
+++ b/.github/workflows/DraftPDF.yml
@@ -1,0 +1,31 @@
+name: Draft JOSS paper PDF
+
+# Builds the JOSS paper with the Open Journals template so rendering and
+# citation errors are caught before submission. The PDF is uploaded as an
+# artifact; nothing is published.
+on:
+  push:
+    paths:
+      - 'paper/**'
+      - '.github/workflows/DraftPDF.yml'
+  pull_request:
+    paths:
+      - 'paper/**'
+      - '.github/workflows/DraftPDF.yml'
+  workflow_dispatch:
+
+jobs:
+  paper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build draft PDF
+        uses: openjournals/openjournals-draft-action@master
+        with:
+          journal: joss
+          paper-path: paper/paper.md
+      - name: Upload PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: paper
+          path: paper/paper.pdf

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,10 +8,11 @@ message: >-
   metadata from this file.
 type: software
 authors:
-  - given-names: Chris
+  - given-names: Christopher A.
     family-names: Waudby
     email: c.waudby@ucl.ac.uk
     affiliation: UCL School of Pharmacy
     orcid: 'https://orcid.org/0000-0001-7810-3753'
-repository-code: 'https://github.com/waudbylab/MulticomplexNumbers.j'
+repository-code: 'https://github.com/waudbylab/MulticomplexNumbers.jl'
 license: MIT
+version: 1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,9 +291,9 @@ julia --project=. -e 'using Pkg; Pkg.test()'
 
 ### Test Coverage
 
-- Tests run on macOS-latest (configurable in CI)
+- Tests run on Linux, macOS, and Windows across Julia 1.10, 1.11, and 1.12
 - Coverage reports uploaded to Codecov
-- Currently testing Julia 1.9 (nightly commented out)
+- A benchmark suite (`benchmark/benchmarks.jl`) runs on pull requests via AirspeedVelocity
 
 ### Testing FFTW Extension
 
@@ -364,8 +364,8 @@ end
 **Trigger**: Push and pull requests
 **Purpose**: Run test suite
 **Matrix**:
-- Julia versions: 1.9 (nightly commented out)
-- OS: macOS-latest (ubuntu-latest and windows-latest commented out)
+- Julia versions: 1.10, 1.11, 1.12
+- OS: ubuntu-latest, macOS-latest, windows-latest
 - Architecture: x64
 
 **Steps**:
@@ -649,6 +649,13 @@ When working with this codebase, always consider type stability, maintain the te
 ---
 
 ## Codebase Analysis & Critique
+
+> **Note (historical):** The critique below predates the JOSS-preparation work.
+> Several weaknesses it lists have since been resolved and should be read in that
+> light: trigonometric/hyperbolic and inverse functions are implemented; `zero`,
+> `one`, `rand`, and `randn` exist; the FFTW extension supports orders 1–4 with
+> `fft!`/`ifft!`/`bfft!`; CI runs on Linux/macOS/Windows across Julia 1.10–1.12;
+> a benchmark suite runs in CI; and the README no longer contains a "TODO: FFT".
 
 ### Overall Assessment
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+c.waudby@ucl.ac.uk.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to MulticomplexNumbers.jl
+
+Thanks for your interest in improving MulticomplexNumbers.jl! Contributions of
+all kinds are welcome — bug reports, documentation fixes, new features, and
+performance improvements.
+
+By participating in this project you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Reporting issues
+
+Please report bugs and request features via the
+[GitHub issue tracker](https://github.com/waudbylab/MulticomplexNumbers.jl/issues).
+
+When reporting a bug, please include:
+
+- A minimal, runnable example that reproduces the problem.
+- What you expected to happen and what actually happened (including any error
+  messages and stack traces).
+- Your Julia version (`versioninfo()`) and the package version (`]status MulticomplexNumbers`).
+
+## Asking questions / getting support
+
+For usage questions, please open a
+[GitHub issue](https://github.com/waudbylab/MulticomplexNumbers.jl/issues) with
+the `question` label, or start a thread in
+[GitHub Discussions](https://github.com/waudbylab/MulticomplexNumbers.jl/discussions)
+if enabled. You can also consult the
+[documentation](https://waudbylab.github.io/MulticomplexNumbers.jl/stable).
+
+## Contributing code
+
+1. **Fork** the repository and create a feature branch from `main`.
+2. **Set up** the development environment:
+   ```julia
+   julia --project=.
+   julia> using Pkg; Pkg.instantiate()
+   ```
+3. **Make your change.** Please follow the conventions already used in the
+   codebase:
+   - Keep operations type-stable and allocation-free where possible (the type is
+     built on `StaticArrays`).
+   - Add docstrings with an example for any new exported function.
+   - Match the existing file organisation (`base.jl`, `arithmetic.jl`,
+     `representations.jl`, `io.jl`).
+4. **Add tests.** Every change should be covered by tests in `test/`, using
+   `@testset`/`@safetestset` and `@inferred` for type-stability checks. Use
+   `≈` (`isapprox`) for floating-point comparisons.
+5. **Run the test suite** locally and make sure it passes:
+   ```julia
+   julia> using Pkg; Pkg.test()
+   ```
+6. **Update documentation** in `docs/src/` if you change or add user-facing
+   behaviour.
+7. **Open a pull request** describing the change and the motivation. CI must pass
+   (tests run on Julia 1.10–1.12 across Linux, macOS, and Windows).
+
+## Development tips
+
+- Build the documentation locally with:
+  ```bash
+  julia --project=docs docs/make.jl
+  ```
+- Check type stability with `@code_warntype` and benchmark performance-sensitive
+  code with `BenchmarkTools.jl` (see `benchmark/`).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE) that covers this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,7 @@ When reporting a bug, please include:
 
 For usage questions, please open a
 [GitHub issue](https://github.com/waudbylab/MulticomplexNumbers.jl/issues) with
-the `question` label, or start a thread in
-[GitHub Discussions](https://github.com/waudbylab/MulticomplexNumbers.jl/discussions)
-if enabled. You can also consult the
+the `question` label. You can also consult the
 [documentation](https://waudbylab.github.io/MulticomplexNumbers.jl/stable).
 
 ## Contributing code

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MulticomplexNumbers"
 uuid = "d39bb3b7-cc9c-4bb9-be86-52b494dfee17"
-version = "0.3.0"
-authors = ["Chris Waudby <c.waudby@ucl.ac.uk> and contributors"]
+version = "1.0.0"
+authors = ["Christopher A. Waudby <c.waudby@ucl.ac.uk> and contributors"]
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -19,7 +19,7 @@ FFTWExt = "FFTW"
 FFTW = "1.7"
 PrecompileTools = "1.1"
 StaticArrays = "1.9"
-julia = "1.9"
+julia = "1.10"
 
 [extras]
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ derivative = imag(f_x) / h  # Returns 12.0 (exact!)
 
 Multicomplex numbers are a generalisation of complex numbers, recursively defined to contain multiple imaginary numbers, $i_1$, $i_2$ etc. Unlike Clifford algebras, these numbers commute, i.e. $i_1i_2=i_2i_1$.
 
-The primary application is a natural, exact representation of **multi-dimensional NMR spectroscopy** data: each quadrature dimension of an _n_-dimensional experiment maps to one imaginary unit of an order-_n_ multicomplex number, so the per-dimension Fourier transforms and phase corrections become ordinary multicomplex arithmetic ([Delsuc, 1988](https://doi.org/10.1016/0022-2364(88)90036-4)). The same construction applies to multi-dimensional **MRI**, where a 2D or 3D image is a bi- or tricomplex array. Multicomplex numbers also enable **high-precision numerical differentiation**: the multicomplex step method computes derivatives — including high-order and mixed partials — with machine precision, avoiding the subtractive cancellation errors of finite differences.
+The primary application is a natural, exact representation of **multi-dimensional NMR spectroscopy** data: each quadrature dimension of an _n_-dimensional experiment maps to one imaginary unit of an order-_n_ multicomplex number, so the per-dimension Fourier transforms and phase corrections become ordinary multicomplex arithmetic ([Delsuc, 1988](https://doi.org/10.1016/0022-2364(88)90036-4)). Multicomplex numbers also enable **high-precision numerical differentiation**: the multicomplex step method computes derivatives — including high-order and mixed partials — with machine precision, avoiding the subtractive cancellation errors of finite differences.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ derivative = imag(f_x) / h  # Returns 12.0 (exact!)
 
 Multicomplex numbers are a generalisation of complex numbers, recursively defined to contain multiple imaginary numbers, $i_1$, $i_2$ etc. Unlike Clifford algebras, these numbers commute, i.e. $i_1i_2=i_2i_1$.
 
-The primary application is **high-precision numerical differentiation**. The multicomplex step method computes derivatives with machine precision, avoiding the subtractive cancellation errors of finite differences. They also provide a natural representation of **multi-dimensional NMR** data.
+The primary application is a natural, exact representation of **multi-dimensional NMR spectroscopy** data: each quadrature dimension of an _n_-dimensional experiment maps to one imaginary unit of an order-_n_ multicomplex number, so the per-dimension Fourier transforms and phase corrections become ordinary multicomplex arithmetic ([Delsuc, 1988](https://doi.org/10.1016/0022-2364(88)90036-4)). Multicomplex numbers also enable **high-precision numerical differentiation**: the multicomplex step method computes derivatives — including high-order and mixed partials — with machine precision, avoiding the subtractive cancellation errors of finite differences.
 
 ## Features
 
@@ -53,6 +53,7 @@ The primary application is **high-precision numerical differentiation**. The mul
 
 ## References
 
+* Delsuc MA. Spectral representation of 2D NMR spectra by hypercomplex numbers. J Magn Reson. 1988;77: 119–124. https://doi.org/10.1016/0022-2364(88)90036-4
 * NIST report on multicomplex algebra: https://nvlpubs.nist.gov/nistpubs/jres/126/jres.126.033.pdf
 * NIST C++ implementation: https://github.com/usnistgov/multicomplex
 * Casado JMV, Hewson R. Algorithm 1008: Multicomplex Number Class for Matlab. ACM Trans Math Softw. 2020;46: 1–26. http://dx.doi.org/10.1145/3378542

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://waudbylab.github.io/MulticomplexNumbers.jl/stable)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://waudbylab.github.io/MulticomplexNumbers.jl/dev)
 [![CI](https://github.com/waudbylab/MulticomplexNumbers.jl/actions/workflows/Runtests.yml/badge.svg)](https://github.com/waudbylab/MulticomplexNumbers.jl/actions/workflows/Runtests.yml)
-[![codecov](https://codecov.io/gh/waudbylab/MulticomplexNumbers.jl/branch/main/graph/badge.svg?token=V9ND8Y3R8A)](https://codecov.io/gh/waudbylab/MulticomplexNumbers.jl)
+[![codecov](https://codecov.io/gh/waudbylab/MulticomplexNumbers.jl/graph/badge.svg?token=V9ND8Y3R8A)](https://codecov.io/gh/waudbylab/MulticomplexNumbers.jl)
 
 ![MulticomplexNumbers logo](logo.png)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ derivative = imag(f_x) / h  # Returns 12.0 (exact!)
 
 Multicomplex numbers are a generalisation of complex numbers, recursively defined to contain multiple imaginary numbers, $i_1$, $i_2$ etc. Unlike Clifford algebras, these numbers commute, i.e. $i_1i_2=i_2i_1$.
 
-The primary application is a natural, exact representation of **multi-dimensional NMR spectroscopy** data: each quadrature dimension of an _n_-dimensional experiment maps to one imaginary unit of an order-_n_ multicomplex number, so the per-dimension Fourier transforms and phase corrections become ordinary multicomplex arithmetic ([Delsuc, 1988](https://doi.org/10.1016/0022-2364(88)90036-4)). Multicomplex numbers also enable **high-precision numerical differentiation**: the multicomplex step method computes derivatives — including high-order and mixed partials — with machine precision, avoiding the subtractive cancellation errors of finite differences.
+The primary application is a natural, exact representation of **multi-dimensional NMR spectroscopy** data: each quadrature dimension of an _n_-dimensional experiment maps to one imaginary unit of an order-_n_ multicomplex number, so the per-dimension Fourier transforms and phase corrections become ordinary multicomplex arithmetic ([Delsuc, 1988](https://doi.org/10.1016/0022-2364(88)90036-4)). The same construction applies to multi-dimensional **MRI**, where a 2D or 3D image is a bi- or tricomplex array. Multicomplex numbers also enable **high-precision numerical differentiation**: the multicomplex step method computes derivatives — including high-order and mixed partials — with machine precision, avoiding the subtractive cancellation errors of finite differences.
 
 ## Features
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -67,6 +67,7 @@ The benchmark suite is organized into the following categories:
 - **hyperbolic**: sinh, cosh, tanh, sech, csch, coth
 - **inverse_trig**: asin, acos, atan, asec, acsc, acot
 - **inverse_hyperbolic**: asinh, acosh, atanh, asech, acsch, acoth
+- **division**: multicomplex division and `inv`
 - **fold**: fold operator and isabient function
 - **conjugation**: Complex conjugation
 - **abs**: Absolute value and abs2
@@ -113,18 +114,31 @@ results_new = run(SUITE)
 comparison = judge(results_new, results_old)
 ```
 
-## Continuous Benchmarking
+## Continuous Benchmarking (CI)
 
-For CI/CD integration, consider using [PkgBenchmark.jl](https://github.com/JuliaCI/PkgBenchmark.jl):
+Benchmarks run automatically on every pull request via
+[`.github/workflows/Benchmarks.yml`](../.github/workflows/Benchmarks.yml), which
+uses [AirspeedVelocity.jl](https://github.com/MilesCranmer/AirspeedVelocity.jl).
+
+The action runs this `SUITE` against both the pull request and the `main` branch,
+then posts (and updates) a comment on the PR with **collapsible tables comparing
+runtime and memory** for every benchmark. A regression therefore shows up as a
+slowdown in the PR comment relative to `main`; there is no separate pass/fail
+threshold, so review the comment when changing performance-sensitive code.
+
+To reproduce the CI comparison locally, install AirspeedVelocity and run
+`benchpkg`:
+
+```bash
+julia -e 'using Pkg; Pkg.add("AirspeedVelocity")'
+benchpkg MulticomplexNumbers --rev=main,dirty
+```
+
+Alternatively, compare manually with [PkgBenchmark.jl](https://github.com/JuliaCI/PkgBenchmark.jl):
 
 ```julia
 using PkgBenchmark
-
-# Benchmark current state
-results = benchmarkpkg("MulticomplexNumbers")
-
-# Compare against a specific commit or tag
-judge("MulticomplexNumbers", "v0.1.0")
+judge("MulticomplexNumbers", "main")  # current checkout vs main
 ```
 
 ## Contributing

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -75,8 +75,10 @@ The benchmark suite is organized into the following categories:
 - **matrep**: Matrix representation generation
 - **random**: Random number generation (rand, randn)
 - **arrays**: Array operations and broadcasting
-- **fft**: In-place multicomplex FFTs (FFTW extension) for 1D–4D data, transforming
-  every dimension against its own imaginary unit (the multi-dimensional NMR case)
+- **fft**: In-place multicomplex FFTs (FFTW extension) on order-N, N-dimensional
+  arrays (N=1–4, the multi-dimensional NMR layout), benchmarking every combination
+  of array dimension `d` and imaginary unit `u` (`fft!(A, u, d)`). Inputs are
+  fixed-seed random arrays, regenerated per sample because `fft!` mutates in place
 
 ## Performance Tips
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,11 +4,11 @@ This directory contains performance benchmarks for the MulticomplexNumbers.jl pa
 
 ## Setup
 
-First, install BenchmarkTools:
+First, install the packages the suite uses:
 
 ```julia
 using Pkg
-Pkg.add("BenchmarkTools")
+Pkg.add(["BenchmarkTools", "StaticArrays", "FFTW"])
 ```
 
 ## Running Benchmarks
@@ -75,6 +75,8 @@ The benchmark suite is organized into the following categories:
 - **matrep**: Matrix representation generation
 - **random**: Random number generation (rand, randn)
 - **arrays**: Array operations and broadcasting
+- **fft**: In-place multicomplex FFTs (FFTW extension) for 1D–4D data, transforming
+  every dimension against its own imaginary unit (the multi-dimensional NMR case)
 
 ## Performance Tips
 
@@ -131,7 +133,8 @@ To reproduce the CI comparison locally, install AirspeedVelocity and run
 
 ```bash
 julia -e 'using Pkg; Pkg.add("AirspeedVelocity")'
-benchpkg MulticomplexNumbers --rev=main,dirty
+# -a passes the extra packages the script needs (kept in sync with the workflow's extra-pkgs)
+benchpkg MulticomplexNumbers --rev=main,dirty -a StaticArrays,FFTW
 ```
 
 Alternatively, compare manually with [PkgBenchmark.jl](https://github.com/JuliaCI/PkgBenchmark.jl):

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -2,6 +2,7 @@ using BenchmarkTools
 using MulticomplexNumbers
 using StaticArrays
 using FFTW  # loads the FFTWExt extension, enabling fft! on multicomplex arrays
+using Random  # for reproducible (fixed-seed) FFT input arrays
 
 # Create a BenchmarkGroup to hold all benchmarks
 const SUITE = BenchmarkGroup()
@@ -203,8 +204,8 @@ SUITE["random"]["randn N=3"] = @benchmarkable randn(Multicomplex{Float64,3,8})
 
 # Array operations
 SUITE["arrays"] = BenchmarkGroup()
-const arr1 = [Multicomplex(1.0, 2.0) for _ in 1:100]
-const arr2 = [Multicomplex(1.0, 2.0, 3.0, 4.0) for _ in 1:100]
+const arr1 = [Multicomplex(1.0, 2.0) for _ in 1:200]
+const arr2 = [Multicomplex(1.0, 2.0, 3.0, 4.0) for _ in 1:200]
 SUITE["arrays"]["sum N=1 array"] = @benchmarkable sum($arr1)
 SUITE["arrays"]["sum N=2 array"] = @benchmarkable sum($arr2)
 SUITE["arrays"]["broadcast add N=1"] = @benchmarkable $arr1 .+ $arr1
@@ -213,22 +214,32 @@ SUITE["arrays"]["broadcast mul scalar N=1"] = @benchmarkable 2.0 .* $arr1
 SUITE["arrays"]["broadcast mul scalar N=2"] = @benchmarkable 2.0 .* $arr2
 
 # Fast Fourier transforms (FFTW extension)
-# An n-dimensional NMR dataset is an order-n multicomplex, n-dimensional array,
-# Fourier transformed along every dimension with that dimension's imaginary unit
-# (i.e. dimension d is transformed against unit i_d via `fft!(A, d, d)`).
+# For an order-N, N-dimensional array (the multi-dimensional NMR layout), we
+# benchmark transforming every combination of array dimension `d` and imaginary
+# unit `u`, i.e. `fft!(A, u, d)` for all u, d in 1:N.
+#
+# Inputs are reproducible: each sample regenerates the array from a fixed seed.
+# `fft!` mutates in place, so a fresh array is needed for every evaluation
+# (hence evals=1); `seconds` caps the time spent on the larger (4D) cases.
 SUITE["fft"] = BenchmarkGroup()
 
-"Transform every dimension of an order-N, N-dimensional array against its own unit."
-function fft_all_dims!(A::AbstractArray{<:Multicomplex{T,N,C}}) where {T,N,C}
-    for d in 1:N
-        fft!(A, d, d)
-    end
-    return A
-end
+# Array sizes per order (doubled from the previous 4096 / 128 / 32 / 16 per dim).
+const FFT_DIMS = Dict(
+    1 => (8192,),
+    2 => (256, 256),
+    3 => (64, 64, 64),
+    4 => (32, 32, 32, 32),
+)
 
-# 1D–4D data (orders 1–4). `fft!` mutates in place, so `setup` regenerates the
-# array for every sample.
-SUITE["fft"]["1D order=1"] = @benchmarkable fft_all_dims!(A) setup=(A = rand(Multicomplex{Float64,1,2}, 4096))
-SUITE["fft"]["2D order=2"] = @benchmarkable fft_all_dims!(A) setup=(A = rand(Multicomplex{Float64,2,4}, 128, 128))
-SUITE["fft"]["3D order=3"] = @benchmarkable fft_all_dims!(A) setup=(A = rand(Multicomplex{Float64,3,8}, 32, 32, 32))
-SUITE["fft"]["4D order=4"] = @benchmarkable fft_all_dims!(A) setup=(A = rand(Multicomplex{Float64,4,16}, 16, 16, 16, 16))
+for N in 1:4
+    dims = FFT_DIMS[N]
+    MT = Multicomplex{Float64, N, 2^N}
+    for d in 1:N, u in 1:N
+        SUITE["fft"]["order=$N dim=$d unit=$u"] = @benchmarkable(
+            fft!(A, $u, $d),
+            setup = (A = rand(MersenneTwister(0x5eed), $MT, $dims...)),
+            evals = 1,
+            seconds = 1
+        )
+    end
+end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,7 @@
 using BenchmarkTools
 using MulticomplexNumbers
 using StaticArrays
+using FFTW  # loads the FFTWExt extension, enabling fft! on multicomplex arrays
 
 # Create a BenchmarkGroup to hold all benchmarks
 const SUITE = BenchmarkGroup()
@@ -210,3 +211,24 @@ SUITE["arrays"]["broadcast add N=1"] = @benchmarkable $arr1 .+ $arr1
 SUITE["arrays"]["broadcast add N=2"] = @benchmarkable $arr2 .+ $arr2
 SUITE["arrays"]["broadcast mul scalar N=1"] = @benchmarkable 2.0 .* $arr1
 SUITE["arrays"]["broadcast mul scalar N=2"] = @benchmarkable 2.0 .* $arr2
+
+# Fast Fourier transforms (FFTW extension)
+# An n-dimensional NMR dataset is an order-n multicomplex, n-dimensional array,
+# Fourier transformed along every dimension with that dimension's imaginary unit
+# (i.e. dimension d is transformed against unit i_d via `fft!(A, d, d)`).
+SUITE["fft"] = BenchmarkGroup()
+
+"Transform every dimension of an order-N, N-dimensional array against its own unit."
+function fft_all_dims!(A::AbstractArray{<:Multicomplex{T,N,C}}) where {T,N,C}
+    for d in 1:N
+        fft!(A, d, d)
+    end
+    return A
+end
+
+# 1D–4D data (orders 1–4). `fft!` mutates in place, so `setup` regenerates the
+# array for every sample.
+SUITE["fft"]["1D order=1"] = @benchmarkable fft_all_dims!(A) setup=(A = rand(Multicomplex{Float64,1,2}, 4096))
+SUITE["fft"]["2D order=2"] = @benchmarkable fft_all_dims!(A) setup=(A = rand(Multicomplex{Float64,2,4}, 128, 128))
+SUITE["fft"]["3D order=3"] = @benchmarkable fft_all_dims!(A) setup=(A = rand(Multicomplex{Float64,3,8}, 32, 32, 32))
+SUITE["fft"]["4D order=4"] = @benchmarkable fft_all_dims!(A) setup=(A = rand(Multicomplex{Float64,4,16}, 16, 16, 16, 16))

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -56,6 +56,9 @@ SUITE["division"] = BenchmarkGroup()
 SUITE["division"]["N=1"] = @benchmarkable $m1 / $m1
 SUITE["division"]["N=2"] = @benchmarkable $m2 / $m2
 SUITE["division"]["N=3"] = @benchmarkable $m3 / $m3
+SUITE["division"]["inv N=1"] = @benchmarkable inv($m1)
+SUITE["division"]["inv N=2"] = @benchmarkable inv($m2)
+SUITE["division"]["inv N=3"] = @benchmarkable inv($m3)
 
 # Powers
 SUITE["powers"] = BenchmarkGroup()
@@ -88,6 +91,12 @@ SUITE["trigonometric"]["cos N=1"] = @benchmarkable cos($m1)
 SUITE["trigonometric"]["cos N=2"] = @benchmarkable cos($m2)
 SUITE["trigonometric"]["tan N=1"] = @benchmarkable tan($m1)
 SUITE["trigonometric"]["tan N=2"] = @benchmarkable tan($m2)
+SUITE["trigonometric"]["sec N=1"] = @benchmarkable sec($m1)
+SUITE["trigonometric"]["sec N=2"] = @benchmarkable sec($m2)
+SUITE["trigonometric"]["csc N=1"] = @benchmarkable csc($m1)
+SUITE["trigonometric"]["csc N=2"] = @benchmarkable csc($m2)
+SUITE["trigonometric"]["cot N=1"] = @benchmarkable cot($m1)
+SUITE["trigonometric"]["cot N=2"] = @benchmarkable cot($m2)
 
 # Hyperbolic functions
 SUITE["hyperbolic"] = BenchmarkGroup()
@@ -97,6 +106,12 @@ SUITE["hyperbolic"]["cosh N=1"] = @benchmarkable cosh($m1)
 SUITE["hyperbolic"]["cosh N=2"] = @benchmarkable cosh($m2)
 SUITE["hyperbolic"]["tanh N=1"] = @benchmarkable tanh($m1)
 SUITE["hyperbolic"]["tanh N=2"] = @benchmarkable tanh($m2)
+SUITE["hyperbolic"]["sech N=1"] = @benchmarkable sech($m1)
+SUITE["hyperbolic"]["sech N=2"] = @benchmarkable sech($m2)
+SUITE["hyperbolic"]["csch N=1"] = @benchmarkable csch($m1)
+SUITE["hyperbolic"]["csch N=2"] = @benchmarkable csch($m2)
+SUITE["hyperbolic"]["coth N=1"] = @benchmarkable coth($m1)
+SUITE["hyperbolic"]["coth N=2"] = @benchmarkable coth($m2)
 
 # Inverse trigonometric functions
 SUITE["inverse_trig"] = BenchmarkGroup()
@@ -108,13 +123,27 @@ SUITE["inverse_trig"]["acos N=1"] = @benchmarkable acos($m1_small)
 SUITE["inverse_trig"]["acos N=2"] = @benchmarkable acos($m2_small)
 SUITE["inverse_trig"]["atan N=1"] = @benchmarkable atan($m1_small)
 SUITE["inverse_trig"]["atan N=2"] = @benchmarkable atan($m2_small)
+SUITE["inverse_trig"]["asec N=1"] = @benchmarkable asec($m1_small)
+SUITE["inverse_trig"]["asec N=2"] = @benchmarkable asec($m2_small)
+SUITE["inverse_trig"]["acsc N=1"] = @benchmarkable acsc($m1_small)
+SUITE["inverse_trig"]["acsc N=2"] = @benchmarkable acsc($m2_small)
+SUITE["inverse_trig"]["acot N=1"] = @benchmarkable acot($m1_small)
+SUITE["inverse_trig"]["acot N=2"] = @benchmarkable acot($m2_small)
 
 # Inverse hyperbolic functions
 SUITE["inverse_hyperbolic"] = BenchmarkGroup()
 SUITE["inverse_hyperbolic"]["asinh N=1"] = @benchmarkable asinh($m1_small)
 SUITE["inverse_hyperbolic"]["asinh N=2"] = @benchmarkable asinh($m2_small)
+SUITE["inverse_hyperbolic"]["acosh N=1"] = @benchmarkable acosh($m1_small)
+SUITE["inverse_hyperbolic"]["acosh N=2"] = @benchmarkable acosh($m2_small)
 SUITE["inverse_hyperbolic"]["atanh N=1"] = @benchmarkable atanh($m1_small)
 SUITE["inverse_hyperbolic"]["atanh N=2"] = @benchmarkable atanh($m2_small)
+SUITE["inverse_hyperbolic"]["asech N=1"] = @benchmarkable asech($m1_small)
+SUITE["inverse_hyperbolic"]["asech N=2"] = @benchmarkable asech($m2_small)
+SUITE["inverse_hyperbolic"]["acsch N=1"] = @benchmarkable acsch($m1_small)
+SUITE["inverse_hyperbolic"]["acsch N=2"] = @benchmarkable acsch($m2_small)
+SUITE["inverse_hyperbolic"]["acoth N=1"] = @benchmarkable acoth($m1_small)
+SUITE["inverse_hyperbolic"]["acoth N=2"] = @benchmarkable acoth($m2_small)
 
 # Fold and isabient
 SUITE["fold"] = BenchmarkGroup()

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -220,7 +220,8 @@ SUITE["arrays"]["broadcast mul scalar N=2"] = @benchmarkable 2.0 .* $arr2
 #
 # Inputs are reproducible: each sample regenerates the array from a fixed seed.
 # `fft!` mutates in place, so a fresh array is needed for every evaluation
-# (hence evals=1); `seconds` caps the time spent on the larger (4D) cases.
+# (hence evals=1). No time cap is set, so the larger (4D) cases simply take
+# longer to collect their samples rather than being cut short.
 SUITE["fft"] = BenchmarkGroup()
 
 # Array sizes per order (doubled from the previous 4096 / 128 / 32 / 16 per dim).
@@ -238,8 +239,7 @@ for N in 1:4
         SUITE["fft"]["order=$N dim=$d unit=$u"] = @benchmarkable(
             fft!(A, $u, $d),
             setup = (A = rand(MersenneTwister(0x5eed), $MT, $dims...)),
-            evals = 1,
-            seconds = 1
+            evals = 1
         )
     end
 end

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # MulticomplexNumbers.jl
 
-A package for representing multicomlex numbers and performing multicomplex algebra.
+A package for representing multicomplex numbers and performing multicomplex algebra.
 
 ## What are Multicomplex Numbers?
 

--- a/paper/SUBMISSION_CHECKLIST.md
+++ b/paper/SUBMISSION_CHECKLIST.md
@@ -40,6 +40,8 @@ Delete this file once the paper is submitted.
 - ✅ API / function documentation — `docs/src/api.md` + docstrings, hosted via Documenter.
 - ✅ Automated tests — `test/` (~420 `@test` assertions, `SafeTestsets`, `@inferred`).
 - ✅ CI — Julia 1.10/1.11/1.12 × Linux/macOS/Windows; Documenter, CompatHelper, TagBot.
+- ✅ Benchmark CI — `.github/workflows/Benchmarks.yml` (AirspeedVelocity) runs the
+  `benchmark/benchmarks.jl` SUITE on each PR and posts a runtime/memory comparison vs `main`.
 - ✅ **Community guidelines** — `CONTRIBUTING.md` (contributing, issues, support) and
   `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) added.
 

--- a/paper/SUBMISSION_CHECKLIST.md
+++ b/paper/SUBMISSION_CHECKLIST.md
@@ -7,68 +7,52 @@ Delete this file once the paper is submitted.
 
 ## Status legend
 - ✅ Done / present in repo
-- ⚠️ Present but should be reviewed/improved
-- ❌ Missing — needs action before submission
+- ⚠️ Present but optional / worth a glance
+- ⬜ Remaining — an external step that can't be done from the repo alone
 
 ## The paper itself
-- ✅ `paper/paper.md` with required YAML front-matter (title, authors, ORCID, affiliation, date, tags, bibliography).
+- ✅ `paper/paper.md` with required YAML front-matter (title, author, ORCID, affiliation, date, tags, bibliography).
 - ✅ `paper/paper.bib` with all cited references and DOIs.
 - ✅ Summary section (high-level, accessible to non-specialists).
 - ✅ Statement of need (audience, comparison to related software).
-- ⚠️ Length: JOSS papers are short (~250–1000 words). Current draft is within range — re-read for concision.
-- ❌ **Verify author details**: confirm full name spelling, affiliation wording, and ORCID
-  (`0000-0001-7810-3753`) are exactly as you want them published. `paper.md` uses
-  "Christopher A. Waudby"; `Project.toml`/`CITATION.cff` use "Chris Waudby" — make these
-  consistent if desired.
-- ❌ **Co-authors / acknowledgements**: confirm there are no other contributors who
-  should be listed as authors, and add a funding statement if any grant supported the work.
-- ⚠️ Optionally compile the paper locally to check rendering/citations using the JOSS
-  Docker image or the [Open Journals GitHub Action](https://github.com/marketplace/actions/open-journals-pdf-generator)
-  before submission (not required, but catches bib errors).
+- ✅ Author name consistent across `paper.md`, `Project.toml`, `CITATION.cff` ("Christopher A. Waudby").
+- ✅ Sole author confirmed; no funding to acknowledge (generic acknowledgements kept).
+- ⚠️ Length is within JOSS's ~250–1000 word range — re-read once more for concision.
+- ⬜ Optionally compile the paper locally (JOSS Docker image or the
+  [Open Journals PDF GitHub Action](https://github.com/marketplace/actions/open-journals-pdf-generator))
+  to verify rendering and that citations resolve.
 
 ## Software substance & scope (JOSS requirements)
 - ✅ Open-source OSI licence (MIT, `LICENSE`).
-- ✅ Research application / "substantial scholarly effort" — multicomplex algebra +
-  high-order differentiation + NMR FFT support.
+- ✅ Research application / "substantial scholarly effort".
 - ✅ Version-controlled public repository.
-- ⚠️ **Tag a release** and **register in the Julia General registry** before/around
-  submission. JOSS asks for a version number and an archived release.
-  Current `Project.toml` version is `0.3.0`; consider tagging a `v0.x`/`v1.0` release.
-- ❌ **Archive a release on Zenodo (or similar)** to obtain a DOI; JOSS requires an
-  archive DOI matching the reviewed version. (Done at the end of review, but set up the
-  Zenodo–GitHub link now.)
+- ✅ Version bumped to `1.0.0` in `Project.toml` and `CITATION.cff`.
+- ⬜ **Tag the `v1.0.0` release** on GitHub and **register in the Julia General
+  registry** (e.g. via the Registrator bot / `@JuliaRegistrator register`).
+- ⬜ **Archive the release on Zenodo** to obtain a DOI matching the reviewed
+  version (set up the Zenodo–GitHub integration before tagging so the tag is
+  captured automatically).
 
 ## Documentation (JOSS requires all four)
-- ✅ Statement of need — covered in README, docs, and paper.
+- ✅ Statement of need — README, docs, and paper.
 - ✅ Installation instructions — README + docs.
-- ✅ Example usage — README quick start, `docs/src/applications/` (differentiation, NMR),
-  `docs/src/guide/`.
+- ✅ Example usage — README quick start, `docs/src/applications/`, `docs/src/guide/`.
 - ✅ API / function documentation — `docs/src/api.md` + docstrings, hosted via Documenter.
-- ✅ Automated tests — `test/` (`base_test.jl`, `fftwext_test.jl`, ~420 `@test` assertions,
-  uses `SafeTestsets` and `@inferred`).
-- ✅ CI — `.github/workflows/Runtests.yml` (Julia 1.10/1.11/1.12 × Linux/macOS/Windows),
-  Documenter, CompatHelper, TagBot.
-- ❌ **Community guidelines** — JOSS expects clear guidance for (1) contributing,
-  (2) reporting issues, (3) seeking support. Add a `CONTRIBUTING.md` and ideally a
-  `CODE_OF_CONDUCT.md`. Currently absent.
-- ⚠️ Consider an issue template pointing to the support/contribution channels.
+- ✅ Automated tests — `test/` (~420 `@test` assertions, `SafeTestsets`, `@inferred`).
+- ✅ CI — Julia 1.10/1.11/1.12 × Linux/macOS/Windows; Documenter, CompatHelper, TagBot.
+- ✅ **Community guidelines** — `CONTRIBUTING.md` (contributing, issues, support) and
+  `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) added.
 
-## Minor consistency / housekeeping fixes
-- ⚠️ **`[compat]` julia version**: `Project.toml` declares `julia = "1.9"` but CI tests
-  1.10–1.12. Bump the compat lower bound to match what is actually tested (e.g. `"1.10"`),
-  or add 1.9 back to the CI matrix.
-- ⚠️ **CLAUDE.md is stale**: it lists trig functions, `zero`/`one`, `rand`, `fold`,
-  `isabient`, broader CI, etc. as "missing/TODO", but these are now implemented/exported.
-  Not required for JOSS, but worth updating to avoid confusion.
-- ⚠️ **Typo** in `docs/src/index.md` line 3: "multicomlex" → "multicomplex". Also
-  `CITATION.cff` `repository-code` ends in `.j` (should be `.jl`).
-- ⚠️ Confirm the README references list and the paper bibliography agree on the
-  citation for the NIST report (Bell & Deiters 2021).
+## Housekeeping (done)
+- ✅ `[compat] julia` bumped to `"1.10"` to match the CI matrix.
+- ✅ Typo fixed in `docs/src/index.md` ("multicomlex" → "multicomplex").
+- ✅ `CITATION.cff` `repository-code` URL fixed (`.j` → `.jl`) and `version` added.
+- ⚠️ `CLAUDE.md` is still stale (lists already-implemented features as TODO). Not a
+  JOSS requirement — update at leisure.
 
 ## Pre-submission final steps
-1. Make the consistency fixes above (author name, compat, typos, community files).
-2. Update CLAUDE.md / docs if desired.
-3. Register the package in the General registry and tag a release.
-4. Set up Zenodo archiving for the repo.
-5. Compile `paper.md` locally to verify it builds and citations resolve.
-6. Submit via https://joss.theoj.org/papers/new with the repository URL and version.
+1. Set up Zenodo ↔ GitHub archiving for the repo.
+2. Tag `v1.0.0` and register the package in the General registry.
+3. Confirm the Zenodo archive DOI for the tagged version.
+4. Compile `paper.md` locally to verify it builds and citations resolve.
+5. Submit via https://joss.theoj.org/papers/new with the repository URL and version.

--- a/paper/SUBMISSION_CHECKLIST.md
+++ b/paper/SUBMISSION_CHECKLIST.md
@@ -1,0 +1,74 @@
+# JOSS Submission Checklist — MulticomplexNumbers.jl
+
+This file tracks what is in place and what still needs doing before submitting to
+the [Journal of Open Source Software](https://joss.theoj.org/). JOSS reviews
+against its [review criteria](https://joss.readthedocs.io/en/latest/review_criteria.html).
+Delete this file once the paper is submitted.
+
+## Status legend
+- ✅ Done / present in repo
+- ⚠️ Present but should be reviewed/improved
+- ❌ Missing — needs action before submission
+
+## The paper itself
+- ✅ `paper/paper.md` with required YAML front-matter (title, authors, ORCID, affiliation, date, tags, bibliography).
+- ✅ `paper/paper.bib` with all cited references and DOIs.
+- ✅ Summary section (high-level, accessible to non-specialists).
+- ✅ Statement of need (audience, comparison to related software).
+- ⚠️ Length: JOSS papers are short (~250–1000 words). Current draft is within range — re-read for concision.
+- ❌ **Verify author details**: confirm full name spelling, affiliation wording, and ORCID
+  (`0000-0001-7810-3753`) are exactly as you want them published. `paper.md` uses
+  "Christopher A. Waudby"; `Project.toml`/`CITATION.cff` use "Chris Waudby" — make these
+  consistent if desired.
+- ❌ **Co-authors / acknowledgements**: confirm there are no other contributors who
+  should be listed as authors, and add a funding statement if any grant supported the work.
+- ⚠️ Optionally compile the paper locally to check rendering/citations using the JOSS
+  Docker image or the [Open Journals GitHub Action](https://github.com/marketplace/actions/open-journals-pdf-generator)
+  before submission (not required, but catches bib errors).
+
+## Software substance & scope (JOSS requirements)
+- ✅ Open-source OSI licence (MIT, `LICENSE`).
+- ✅ Research application / "substantial scholarly effort" — multicomplex algebra +
+  high-order differentiation + NMR FFT support.
+- ✅ Version-controlled public repository.
+- ⚠️ **Tag a release** and **register in the Julia General registry** before/around
+  submission. JOSS asks for a version number and an archived release.
+  Current `Project.toml` version is `0.3.0`; consider tagging a `v0.x`/`v1.0` release.
+- ❌ **Archive a release on Zenodo (or similar)** to obtain a DOI; JOSS requires an
+  archive DOI matching the reviewed version. (Done at the end of review, but set up the
+  Zenodo–GitHub link now.)
+
+## Documentation (JOSS requires all four)
+- ✅ Statement of need — covered in README, docs, and paper.
+- ✅ Installation instructions — README + docs.
+- ✅ Example usage — README quick start, `docs/src/applications/` (differentiation, NMR),
+  `docs/src/guide/`.
+- ✅ API / function documentation — `docs/src/api.md` + docstrings, hosted via Documenter.
+- ✅ Automated tests — `test/` (`base_test.jl`, `fftwext_test.jl`, ~420 `@test` assertions,
+  uses `SafeTestsets` and `@inferred`).
+- ✅ CI — `.github/workflows/Runtests.yml` (Julia 1.10/1.11/1.12 × Linux/macOS/Windows),
+  Documenter, CompatHelper, TagBot.
+- ❌ **Community guidelines** — JOSS expects clear guidance for (1) contributing,
+  (2) reporting issues, (3) seeking support. Add a `CONTRIBUTING.md` and ideally a
+  `CODE_OF_CONDUCT.md`. Currently absent.
+- ⚠️ Consider an issue template pointing to the support/contribution channels.
+
+## Minor consistency / housekeeping fixes
+- ⚠️ **`[compat]` julia version**: `Project.toml` declares `julia = "1.9"` but CI tests
+  1.10–1.12. Bump the compat lower bound to match what is actually tested (e.g. `"1.10"`),
+  or add 1.9 back to the CI matrix.
+- ⚠️ **CLAUDE.md is stale**: it lists trig functions, `zero`/`one`, `rand`, `fold`,
+  `isabient`, broader CI, etc. as "missing/TODO", but these are now implemented/exported.
+  Not required for JOSS, but worth updating to avoid confusion.
+- ⚠️ **Typo** in `docs/src/index.md` line 3: "multicomlex" → "multicomplex". Also
+  `CITATION.cff` `repository-code` ends in `.j` (should be `.jl`).
+- ⚠️ Confirm the README references list and the paper bibliography agree on the
+  citation for the NIST report (Bell & Deiters 2021).
+
+## Pre-submission final steps
+1. Make the consistency fixes above (author name, compat, typos, community files).
+2. Update CLAUDE.md / docs if desired.
+3. Register the package in the General registry and tag a release.
+4. Set up Zenodo archiving for the repo.
+5. Compile `paper.md` locally to verify it builds and citations resolve.
+6. Submit via https://joss.theoj.org/papers/new with the repository URL and version.

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -63,6 +63,17 @@
   doi     = {10.1016/j.cam.2007.07.026}
 }
 
+@article{Delsuc1988,
+  author  = {Delsuc, Marc A.},
+  title   = {Spectral Representation of {2D} {NMR} Spectra by Hypercomplex Numbers},
+  journal = {Journal of Magnetic Resonance},
+  volume  = {77},
+  number  = {1},
+  pages   = {119--124},
+  year    = {1988},
+  doi     = {10.1016/0022-2364(88)90036-4}
+}
+
 @article{Revels2016,
   author  = {Revels, Jarrett and Lubin, Miles and Papamarkou, Theodore},
   title   = {Forward-Mode Automatic Differentiation in Julia},

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -74,6 +74,26 @@
   doi     = {10.1016/0022-2364(88)90036-4}
 }
 
+@article{AguirreMesa2020,
+  author  = {Aguirre-Mesa, Andres M. and Garcia, Manuel J. and Millwater, Harry},
+  title   = {{MultiZ}: A Library for Computation of High-Order Derivatives Using Multicomplex or Multidual Numbers},
+  journal = {ACM Transactions on Mathematical Software},
+  volume  = {46},
+  number  = {3},
+  pages   = {1--28},
+  year    = {2020},
+  doi     = {10.1145/3378538}
+}
+
+@book{LunaElizarraras2015,
+  author    = {Luna-Elizarrar{\'a}s, M. Elena and Shapiro, Michael and Struppa, Daniele C. and Vajiac, Adrian},
+  title     = {Bicomplex Holomorphic Functions: The Algebra, Geometry and Analysis of Bicomplex Numbers},
+  publisher = {Birkh{\"a}user Cham},
+  series    = {Frontiers in Mathematics},
+  year      = {2015},
+  doi       = {10.1007/978-3-319-24868-4}
+}
+
 @article{Revels2016,
   author  = {Revels, Jarrett and Lubin, Miles and Papamarkou, Theodore},
   title   = {Forward-Mode Automatic Differentiation in Julia},

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,0 +1,72 @@
+@article{Bezanson2017,
+  author  = {Bezanson, Jeff and Edelman, Alan and Karpinski, Stefan and Shah, Viral B.},
+  title   = {Julia: A Fresh Approach to Numerical Computing},
+  journal = {SIAM Review},
+  volume  = {59},
+  number  = {1},
+  pages   = {65--98},
+  year    = {2017},
+  doi     = {10.1137/141000671}
+}
+
+@article{Bell2021,
+  author  = {Bell, Ian H. and Deiters, Ulrich K.},
+  title   = {Precise Numerical Differentiation of Thermodynamic Functions with Multicomplex Variables},
+  journal = {Journal of Research of the National Institute of Standards and Technology},
+  volume  = {126},
+  pages   = {126033},
+  year    = {2021},
+  doi     = {10.6028/jres.126.033}
+}
+
+@article{Casado2020,
+  author  = {Casado, Jose Maria Varas and Hewson, Rob},
+  title   = {Algorithm 1008: Multicomplex Number Class for Matlab, with a Focus on the Accurate Calculation of Small Imaginary Terms for Multicomplex Step Sensitivity Calculations},
+  journal = {ACM Transactions on Mathematical Software},
+  volume  = {46},
+  number  = {2},
+  pages   = {1--26},
+  year    = {2020},
+  doi     = {10.1145/3378542}
+}
+
+@article{Lantoine2012,
+  author  = {Lantoine, Gregory and Russell, Ryan P. and Dargent, Thierry},
+  title   = {Using Multicomplex Variables for Automatic Computation of High-Order Derivatives},
+  journal = {ACM Transactions on Mathematical Software},
+  volume  = {38},
+  number  = {3},
+  pages   = {1--21},
+  year    = {2012},
+  doi     = {10.1145/2168773.2168774}
+}
+
+@article{Squire1998,
+  author  = {Squire, William and Trapp, George},
+  title   = {Using Complex Variables to Estimate Derivatives of Real Functions},
+  journal = {SIAM Review},
+  volume  = {40},
+  number  = {1},
+  pages   = {110--112},
+  year    = {1998},
+  doi     = {10.1137/S003614459631241X}
+}
+
+@article{Lai2008,
+  author  = {Lai, K.-L. and Crassidis, J. L.},
+  title   = {Extensions of the first and second complex-step derivative approximations},
+  journal = {Journal of Computational and Applied Mathematics},
+  volume  = {219},
+  number  = {1},
+  pages   = {276--293},
+  year    = {2008},
+  doi     = {10.1016/j.cam.2007.07.026}
+}
+
+@article{Revels2016,
+  author  = {Revels, Jarrett and Lubin, Miles and Papamarkou, Theodore},
+  title   = {Forward-Mode Automatic Differentiation in Julia},
+  journal = {arXiv preprint arXiv:1607.07892},
+  year    = {2016},
+  doi     = {10.48550/arXiv.1607.07892}
+}

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -14,7 +14,7 @@ authors:
 affiliations:
   - name: UCL School of Pharmacy, University College London, London, United Kingdom
     index: 1
-date: 27 June 2026
+date: 30 June 2026
 bibliography: paper.bib
 ---
 
@@ -31,10 +31,11 @@ setting for analytic computation [@Bell2021; @Casado2020].
 The package provides a single parametric `Multicomplex{T,N,C}` number type that
 integrates fully with Julia's `Number` interface, including promotion and
 conversion rules, so that multicomplex numbers can be used as a drop-in scalar
-type in generic numerical code. It implements the full set of elementary
+type in generic numerical code. Here, `T` is the base type, `N` the number of
+imaginary units, and `C=2^N`. The package implements the full set of elementary
 arithmetic and transcendental operations ($+$, $-$, $\times$, $/$, powers,
 `exp`, `log`, `sqrt`, and the trigonometric and hyperbolic functions and their
-inverses), together with matrix representations, conjugation, the fold/division
+inverses), together with matrix representations, conjugation, fold/division
 algorithm, and views that reinterpret arrays of multicomplex numbers as nested
 complex arrays. The type is built on stack-allocated `StaticArrays` storage and
 is type-stable, so arithmetic is allocation-free and competitive with hand-written
@@ -102,14 +103,10 @@ and (iii) it provides a multicomplex FFT for the multi-dimensional NMR
 application, with no counterpart in the reference implementations. The package is
 used in production by the NMR data-analysis package `NMRTools.jl`.
 
-The package ships with an extensive test suite that checks both numerical
+The package ships with a test suite that checks both numerical
 accuracy and type stability across orders, a benchmark suite run in continuous
 integration, and documentation comprising a mathematical background, a user
 guide, and worked application examples.
 
-# Acknowledgements
-
-We thank the developers of the NIST multicomplex C++ library and the authors of
-Algorithm 1008, whose algorithms informed this implementation.
 
 # References

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,0 +1,90 @@
+---
+title: 'MulticomplexNumbers.jl: Multicomplex algebra and high-order numerical differentiation in Julia'
+tags:
+  - Julia
+  - multicomplex numbers
+  - hypercomplex algebra
+  - numerical differentiation
+  - automatic differentiation
+  - NMR spectroscopy
+authors:
+  - name: Christopher A. Waudby
+    orcid: 0000-0001-7810-3753
+    affiliation: 1
+affiliations:
+  - name: UCL School of Pharmacy, University College London, London, United Kingdom
+    index: 1
+date: 27 June 2026
+bibliography: paper.bib
+---
+
+# Summary
+
+`MulticomplexNumbers.jl` is a Julia package for representing multicomplex numbers
+and performing multicomplex algebra. Multicomplex numbers are a commutative
+generalisation of the complex numbers, defined recursively to contain an
+arbitrary number of imaginary units $i_1, i_2, \ldots, i_n$, each squaring to
+$-1$. Unlike quaternions or other Clifford (geometric) algebras, the imaginary
+units commute ($i_j i_k = i_k i_j$), which makes the resulting algebra a natural
+setting for analytic computation [@Bell2021; @Casado2020].
+
+The package provides a single parametric `Multicomplex{T,N,C}` number type that
+integrates fully with Julia's `Number` interface, including promotion and
+conversion rules, so that multicomplex numbers can be used as a drop-in scalar
+type in generic numerical code. It implements the full set of elementary
+arithmetic and transcendental operations ($+$, $-$, $\times$, $/$, powers,
+`exp`, `log`, `sqrt`, and the trigonometric and hyperbolic functions and their
+inverses), together with matrix representations, conjugation, the fold/division
+algorithm, and views that reinterpret arrays of multicomplex numbers as nested
+complex arrays. The type is built on stack-allocated `StaticArrays` storage and
+is type-stable, so arithmetic is allocation-free and competitive with hand-written
+complex code. An optional package extension adds in-place multicomplex fast
+Fourier transforms when `FFTW` is loaded.
+
+# Statement of need
+
+The principal motivation for multicomplex arithmetic is **high-order numerical
+differentiation**. The complex-step derivative approximation,
+$f'(x) \approx \operatorname{Im}\,f(x + i h)/h$, computes first derivatives to
+machine precision because it avoids the subtractive cancellation that limits
+finite-difference schemes, allowing step sizes as small as $h = 10^{-100}$
+[@Squire1998; @Lai2008]. Multicomplex numbers extend this idea to arbitrary
+order: by promoting a function argument to a multicomplex number with several
+independent infinitesimal imaginary perturbations, mixed and higher-order
+partial derivatives can be recovered, again without cancellation error, from the
+appropriate components of the result [@Lantoine2012; @Bell2021]. This makes the
+multicomplex step method attractive whenever exact, high-order derivatives of an
+existing scalar function are required and the source can simply be re-run with a
+different number type — for example in sensitivity analysis, optimisation, and
+the differentiation of thermodynamic functions [@Bell2021].
+
+While Julia has a mature automatic-differentiation ecosystem (e.g.
+`ForwardDiff.jl` [@Revels2016] and `DualNumbers.jl`), these packages are based on
+dual and hyper-dual numbers, which carry truncated Taylor coefficients rather
+than forming a closed division algebra. Multicomplex numbers are complementary:
+they are an exact algebraic field-like structure (a true generalisation of $\mathbb{C}$),
+they reproduce ordinary complex arithmetic exactly at order one, and the same
+objects that encode derivatives also serve as a faithful representation of
+multi-dimensional, multi-phase data. Prior implementations exist as a NIST C++
+library [@Bell2021] and as a MATLAB class [@Casado2020], but before this work
+there was no native, type-stable, generically-typed implementation for Julia.
+
+A second motivating application is **multi-dimensional NMR spectroscopy**, where
+each indirectly-detected dimension carries an independent real/imaginary phase
+pair. An $n$-dimensional NMR experiment is naturally represented by an array of
+order-$n$ multicomplex numbers, and the package's `FFTW` extension performs the
+per-dimension Fourier transforms and phase corrections directly on this
+representation. `MulticomplexNumbers.jl` underpins the NMR data-handling package
+`NMRTools.jl`.
+
+The package supports any `Real` base type, including `BigFloat` for
+arbitrary-precision work, ships with an extensive test suite that checks both
+numerical accuracy and type stability across orders, and is documented with a
+mathematical background, a user guide, and worked application examples.
+
+# Acknowledgements
+
+We thank the developers of the NIST multicomplex C++ library and the authors of
+Algorithm 1008, whose algorithms informed this implementation.
+
+# References

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -43,15 +43,29 @@ Fourier transforms when `FFTW` is loaded.
 
 # Statement of need
 
-The principal motivation for multicomplex arithmetic is **high-order numerical
-differentiation**. The complex-step derivative approximation,
+The motivating application for this package is **multi-dimensional nuclear
+magnetic resonance (NMR) spectroscopy**. Each independently sampled (indirect)
+time dimension of an NMR experiment is acquired in quadrature, carrying its own
+real/imaginary (cosine/sine) phase pair, so an $n$-dimensional experiment is
+naturally and exactly represented by an array of order-$n$ multicomplex numbers,
+with the imaginary unit $i_k$ attached to dimension $k$ [@Delsuc1988]. Holding
+the data in this representation lets an entire processing pipeline — apodization,
+the per-dimension Fourier transforms, and phase correction applied independently
+in each dimension — be written as ordinary multicomplex arithmetic, instead of
+manually bookkeeping the $2^n$ interleaved real arrays of a "hypercomplex"
+dataset. `MulticomplexNumbers.jl` provides this representation together with an
+`FFTW`-backed in-place multicomplex FFT, and underpins the NMR data-handling
+package `NMRTools.jl`.
+
+The same algebra also enables **high-order numerical differentiation**. The
+complex-step derivative approximation,
 $f'(x) \approx \operatorname{Im}\,f(x + i h)/h$, computes first derivatives to
 machine precision because it avoids the subtractive cancellation that limits
 finite-difference schemes, allowing step sizes as small as $h = 10^{-100}$
 [@Squire1998; @Lai2008]. Multicomplex numbers extend this idea to arbitrary
 order: by promoting a function argument to a multicomplex number with several
-independent infinitesimal imaginary perturbations, mixed and higher-order
-partial derivatives can be recovered, again without cancellation error, from the
+independent infinitesimal imaginary perturbations, mixed and higher-order partial
+derivatives can be recovered, again without cancellation error, from the
 appropriate components of the result [@Lantoine2012; @Bell2021]. This makes the
 multicomplex step method attractive whenever exact, high-order derivatives of an
 existing scalar function are required and the source can simply be re-run with a
@@ -61,21 +75,13 @@ the differentiation of thermodynamic functions [@Bell2021].
 While Julia has a mature automatic-differentiation ecosystem (e.g.
 `ForwardDiff.jl` [@Revels2016] and `DualNumbers.jl`), these packages are based on
 dual and hyper-dual numbers, which carry truncated Taylor coefficients rather
-than forming a closed division algebra. Multicomplex numbers are complementary:
-they are an exact algebraic field-like structure (a true generalisation of $\mathbb{C}$),
-they reproduce ordinary complex arithmetic exactly at order one, and the same
-objects that encode derivatives also serve as a faithful representation of
-multi-dimensional, multi-phase data. Prior implementations exist as a NIST C++
-library [@Bell2021] and as a MATLAB class [@Casado2020], but before this work
-there was no native, type-stable, generically-typed implementation for Julia.
-
-A second motivating application is **multi-dimensional NMR spectroscopy**, where
-each indirectly-detected dimension carries an independent real/imaginary phase
-pair. An $n$-dimensional NMR experiment is naturally represented by an array of
-order-$n$ multicomplex numbers, and the package's `FFTW` extension performs the
-per-dimension Fourier transforms and phase corrections directly on this
-representation. `MulticomplexNumbers.jl` underpins the NMR data-handling package
-`NMRTools.jl`.
+than forming a closed algebra. Multicomplex numbers are complementary: they are
+an exact algebraic structure (a true generalisation of $\mathbb{C}$), they
+reproduce ordinary complex arithmetic exactly at order one, and the same objects
+that represent multi-phase data also encode derivatives. Prior implementations
+exist as a NIST C++ library [@Bell2021] and as a MATLAB class [@Casado2020], but
+before this work there was no native, type-stable, generically-typed
+implementation for Julia.
 
 The package supports any `Real` base type, including `BigFloat` for
 arbitrary-precision work, ships with an extensive test suite that checks both

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'MulticomplexNumbers.jl: Multicomplex algebra and high-order numerical differentiation in Julia'
+title: 'MulticomplexNumbers.jl: Commutative hypercomplex algebra in Julia for multidimensional NMR and numerical differentiation'
 tags:
   - Julia
   - multicomplex numbers

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -72,21 +72,28 @@ existing scalar function are required and the source can simply be re-run with a
 different number type — for example in sensitivity analysis, optimisation, and
 the differentiation of thermodynamic functions [@Bell2021].
 
-While Julia has a mature automatic-differentiation ecosystem (e.g.
-`ForwardDiff.jl` [@Revels2016] and `DualNumbers.jl`), these packages are based on
-dual and hyper-dual numbers, which carry truncated Taylor coefficients rather
-than forming a closed algebra. Multicomplex numbers are complementary: they are
-an exact algebraic structure (a true generalisation of $\mathbb{C}$), they
-reproduce ordinary complex arithmetic exactly at order one, and the same objects
-that represent multi-phase data also encode derivatives. Prior implementations
-exist as a NIST C++ library [@Bell2021] and as a MATLAB class [@Casado2020], but
-before this work there was no native, type-stable, generically-typed
-implementation for Julia.
+Existing implementations of multicomplex arithmetic are available in other
+languages — a C++ library from NIST [@Bell2021] and the MATLAB class of
+Algorithm 1008 [@Casado2020] — but neither is usable from Julia, and both fix
+the scalar type to double precision. Within Julia, the established tools for
+derivative computation are dual-number based: `ForwardDiff.jl` [@Revels2016],
+`DualNumbers.jl`, and `HyperDualNumbers.jl` propagate truncated Taylor
+coefficients rather than forming a closed algebra, and target differentiation
+specifically rather than providing a general hypercomplex number type.
+`MulticomplexNumbers.jl` is, to our knowledge, the first native Julia
+implementation of multicomplex algebra, and it differs from this prior art in
+three ways that matter for research use: (i) it is fully generic in the base
+type, so the same code runs in `Float64`, `BigFloat`, or any other `Real`; (ii)
+it is a first-class `Number` subtype with promotion and conversion rules, so it
+composes with Julia's existing array, linear-algebra, and FFT code without
+modification; and (iii) it provides a multicomplex FFT for the multi-dimensional
+NMR application, which has no counterpart in the reference implementations. The
+package is used in production by the NMR data-analysis package `NMRTools.jl`.
 
-The package supports any `Real` base type, including `BigFloat` for
-arbitrary-precision work, ships with an extensive test suite that checks both
-numerical accuracy and type stability across orders, and is documented with a
-mathematical background, a user guide, and worked application examples.
+The package ships with an extensive test suite that checks both numerical
+accuracy and type stability across orders, a benchmark suite run in continuous
+integration, and documentation comprising a mathematical background, a user
+guide, and worked application examples.
 
 # Acknowledgements
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -48,7 +48,11 @@ magnetic resonance (NMR) spectroscopy**. Each independently sampled (indirect)
 time dimension of an NMR experiment is acquired in quadrature, carrying its own
 real/imaginary (cosine/sine) phase pair, so an $n$-dimensional experiment is
 naturally and exactly represented by an array of order-$n$ multicomplex numbers,
-with the imaginary unit $i_k$ attached to dimension $k$ [@Delsuc1988]. Holding
+with the imaginary unit $i_k$ attached to dimension $k$ [@Delsuc1988]. The same
+construction applies to any multi-dimensional Fourier experiment whose dimensions
+are each encoded in independent quadrature, including multi-dimensional magnetic
+resonance imaging (MRI), where a two- or three-dimensional image is a bi- or
+tricomplex array. Holding
 the data in this representation lets an entire processing pipeline — apodization,
 the per-dimension Fourier transforms, and phase correction applied independently
 in each dimension — be written as ordinary multicomplex arithmetic, instead of

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -48,11 +48,7 @@ magnetic resonance (NMR) spectroscopy**. Each independently sampled (indirect)
 time dimension of an NMR experiment is acquired in quadrature, carrying its own
 real/imaginary (cosine/sine) phase pair, so an $n$-dimensional experiment is
 naturally and exactly represented by an array of order-$n$ multicomplex numbers,
-with the imaginary unit $i_k$ attached to dimension $k$ [@Delsuc1988]. The same
-construction applies to any multi-dimensional Fourier experiment whose dimensions
-are each encoded in independent quadrature, including multi-dimensional magnetic
-resonance imaging (MRI), where a two- or three-dimensional image is a bi- or
-tricomplex array. Holding
+with the imaginary unit $i_k$ attached to dimension $k$ [@Delsuc1988]. Holding
 the data in this representation lets an entire processing pipeline — apodization,
 the per-dimension Fourier transforms, and phase correction applied independently
 in each dimension — be written as ordinary multicomplex arithmetic, instead of
@@ -76,23 +72,35 @@ existing scalar function are required and the source can simply be re-run with a
 different number type — for example in sensitivity analysis, optimisation, and
 the differentiation of thermodynamic functions [@Bell2021].
 
-Existing implementations of multicomplex arithmetic are available in other
-languages — a C++ library from NIST [@Bell2021] and the MATLAB class of
-Algorithm 1008 [@Casado2020] — but neither is usable from Julia, and both fix
-the scalar type to double precision. Within Julia, the established tools for
-derivative computation are dual-number based: `ForwardDiff.jl` [@Revels2016],
-`DualNumbers.jl`, and `HyperDualNumbers.jl` propagate truncated Taylor
-coefficients rather than forming a closed algebra, and target differentiation
-specifically rather than providing a general hypercomplex number type.
-`MulticomplexNumbers.jl` is, to our knowledge, the first native Julia
+Multicomplex arithmetic has been implemented before in other languages — a C++
+library from NIST [@Bell2021], the MATLAB class of Algorithm 1008 [@Casado2020],
+and the C++/Python library `MultiZ` [@AguirreMesa2020] — but none is usable from
+Julia, and all fix the base type to double precision. These libraries are applied
+chiefly to exact high-order derivatives and sensitivity analysis in engineering,
+for example in solid mechanics, fracture, and design optimisation
+[@AguirreMesa2020], while the order-two (bicomplex, or *tessarine*) case also
+underlies bicomplex function theory and arises in signal processing and bicomplex
+quantum mechanics [@LunaElizarraras2015].
+
+Within the Julia ecosystem, the established tools for derivative computation are
+based on dual numbers: `ForwardDiff.jl` [@Revels2016] implements forward-mode
+automatic differentiation, `DualNumbers.jl` provides first-order dual numbers,
+and `HyperDualNumbers.jl` provides hyper-dual numbers for exact second
+derivatives. These carry truncated Taylor coefficients rather than forming a
+closed algebra, and are specialised for differentiation rather than offering a
+general hypercomplex number type. `CliffordAlgebras.jl` implements Clifford and
+geometric algebras, but there the generating units anticommute
+($e_j e_k = -e_k e_j$); multicomplex units instead commute, giving a different
+algebra better suited to data with several independent, factorised phase
+dimensions. `MulticomplexNumbers.jl` is, to our knowledge, the first native Julia
 implementation of multicomplex algebra, and it differs from this prior art in
-three ways that matter for research use: (i) it is fully generic in the base
-type, so the same code runs in `Float64`, `BigFloat`, or any other `Real`; (ii)
-it is a first-class `Number` subtype with promotion and conversion rules, so it
-composes with Julia's existing array, linear-algebra, and FFT code without
-modification; and (iii) it provides a multicomplex FFT for the multi-dimensional
-NMR application, which has no counterpart in the reference implementations. The
-package is used in production by the NMR data-analysis package `NMRTools.jl`.
+three ways that matter for research use: (i) it is generic in the base type, so
+the same code runs in `Float64`, `BigFloat`, or any other `Real`; (ii) it is a
+first-class `Number` subtype with promotion and conversion rules, so it composes
+with Julia's existing array, linear-algebra, and FFT code without modification;
+and (iii) it provides a multicomplex FFT for the multi-dimensional NMR
+application, with no counterpart in the reference implementations. The package is
+used in production by the NMR data-analysis package `NMRTools.jl`.
 
 The package ships with an extensive test suite that checks both numerical
 accuracy and type stability across orders, a benchmark suite run in continuous

--- a/test/examples_test.jl
+++ b/test/examples_test.jl
@@ -1,0 +1,34 @@
+# Executable versions of the examples shown in the README and documentation,
+# so that the advertised usage cannot silently break. Kept deliberately small
+# and dependency-free (no FFTW); the FFT examples are covered by fftwext_test.jl.
+
+using MulticomplexNumbers
+using Test
+
+@testset "README quick start" begin
+    z = 1.0 + 2.0 * im1           # order 1 (complex)
+    w = 1.0 + 2.0 * im1 + 3.0 * im2   # order 2 (bicomplex)
+
+    @test order(z) == 1
+    @test order(w) == 2
+
+    # arithmetic runs and promotes to the higher order
+    @test order(z * w) == 2
+    @test w + w ≈ 2.0 * w
+    @test exp(w) isa Multicomplex
+    @test sqrt(w)^2 ≈ w
+end
+
+@testset "multicomplex-step differentiation" begin
+    f(x) = x^3
+
+    # First derivative: f'(2) = 3*2^2 = 12, recovered with no cancellation.
+    h = 1e-100
+    x = 2.0 + h * im1
+    @test imag(f(x)) / h ≈ 12.0
+
+    # Second derivative via the bicomplex step: f''(2) = 6*2 = 12.
+    # The i1*i2 component (index 4) holds h^2 * f''(x).
+    y = 2.0 + h * im1 + h * im2
+    @test component(f(y), 4) / h^2 ≈ 12.0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,10 @@ using SafeTestsets
     include("base_test.jl")
 end
 
+@safetestset "Documented examples" begin
+    include("examples_test.jl")
+end
+
 @safetestset "FFTWExt" begin
     include("fftwext_test.jl")
 end


### PR DESCRIPTION
## Summary

Prepares the package for a Journal of Open Source Software (JOSS) submission and a v1.0.0 release.

### JOSS paper
- Adds `paper/paper.md` (summary + statement of need) and `paper/paper.bib` with cited references and DOIs.
- The statement of need **leads with multi-dimensional NMR spectroscopy** as the primary application, with high-order numerical differentiation as the second; adds the Delsuc (1988) hypercomplex-NMR reference.
- Adds `paper/SUBMISSION_CHECKLIST.md` tracking remaining (external) steps.

### v1.0.0 release prep
- Bumps version to `1.0.0` (`Project.toml`, `CITATION.cff`).
- Bumps `[compat] julia` to `1.10` to match the CI matrix.
- Standardises the author name to "Christopher A. Waudby" across `paper.md`, `Project.toml`, `CITATION.cff`.

### Community guidelines (JOSS requirement)
- Adds `CONTRIBUTING.md` (contributing / issue reporting / support).
- Adds `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1).

### Benchmark CI
- Adds `.github/workflows/Benchmarks.yml` using AirspeedVelocity: runs the `benchmark/benchmarks.jl` SUITE on each PR and posts a runtime/memory comparison comment vs `main`.
- Brings the suite up to date with the implemented API: adds `sec/csc/cot`, `sech/csch/coth`, `asec/acsc/acot`, `acosh/asech/acsch/acoth`, and `inv`.
- Adds **FFTW benchmarks** for 1D–4D data, transforming every dimension against its own imaginary unit (the multi-dimensional NMR case); passes `StaticArrays,FFTW` via the workflow's `extra-pkgs`.

### Housekeeping
- Fixes a typo in `docs/src/index.md` and the `repository-code` URL in `CITATION.cff`.

## Notes / follow-ups
- Benchmark CI first runs on this PR (Julia isn't available in the authoring environment, so the suite hasn't been executed locally) — the workflow run here is its first validation.
- Remaining external steps before JOSS submission: register `v1.0.0` in the General registry, set up Zenodo archiving for the release DOI, and optionally compile `paper.md` locally to verify citations.
- Please double-check the Delsuc (1988) DOI in `paper.bib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014HnHLNVEiHzvjR2TV9TSaG)_